### PR TITLE
Update code option

### DIFF
--- a/ba/ba.cpp
+++ b/ba/ba.cpp
@@ -920,7 +920,7 @@ int main(int argc, char** argv) {
   OptionFlags engineOpts {
     {"debug.instrumentCompute", "true"},
     {"debug.computeInstrumentationLevel", "tile"},
-    {"target.workerStackSizeInBytes", "4096"}
+    {"debug.workerStackSizeInBytes", "4096"}
   };
 
   enum ProgamIds {

--- a/ba/slam.cpp
+++ b/ba/slam.cpp
@@ -931,7 +931,7 @@ int main(int argc, char** argv) {
   OptionFlags engineOpts {
     {"debug.instrumentCompute", "true"},
     {"debug.computeInstrumentationLevel", "tile"},
-    {"target.workerStackSizeInBytes", "4096"}
+    {"debug.workerStackSizeInBytes", "4096"}
   };
 
   enum ProgamIds {


### PR DESCRIPTION
@joeaortiz - first of all, thanks for sharing the source code for your paper! 

I was just trying your code on a Graphcore Pod64 IPU server to see the effectiveness of IPU for BA / SLAM purposes.

Following your instructions, I've got the error shown below:

```
poplaruser1-3@ipu-pod64-mgmt:~/ba/gbp-poplar/ba$ ./ba --bal_file ../sequences/fr1xyz.txt 
Completed loading data!

Bundle Adjustment

Number of keyframe nodes in the graph: 42
Number of landmark nodes in the graph: 2194
Number of edges in the graph: 12908

Number of IPUs: 1
Number of keyframe / landmark / factor nodes per tile: 1 / 2 / 11
Number of tiles used by camera / landmark / factor nodes / total : 42 / 1097 / 1174 / 1216

Attaching to IPU device...
Attached to device: 0
terminate called after throwing an instance of 'poplar::invalid_option'
  what(): Unrecognised option 'target.workerStackSizeInBytes'
Aborted
```

When I looked up the `target.workerStackSizeInBytes` option, I've got `debug.workerStackSizeInBytes` instead from the [official document](https://docs.graphcore.ai/projects/poplar-api/en/latest/poplar_api.html).

![image](https://user-images.githubusercontent.com/39010111/103520167-164d9980-4eba-11eb-9ad4-d1cba2abf3be.png)

**So I replaced the code with `debug.workerStackSizeInBytes`, then saw the code running.**


I'm not exactly sure why this works - since the `debug.workerStackSizeInBytes` options have never been changed from its older versions. And I'm also not too sure about what the original intent of the `target.workerStackSizeInBytes` is either, since I am very inexperienced in Poplar.

Please take a look at the changes, and let me know if these changes are appropriate :smile_cat: 